### PR TITLE
update dependencies to use latest otel crates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,29 +1,12 @@
 name: Release and Publish
 on:
-  pull_request:
-    branches:
-      - main
-      - "release/v[0-9]+.[0-9]+"
   push:
-    branches:
-      - 'main'
-      - 'release/v[0-9]+.[0-9]+'
-jobs:
-  changelog:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "✏️ Generate release changelog"
-        uses: heinrichreimer/github-changelog-generator-action@v2.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }} 
-      - name: Git Auto Commit
-        id: commit
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          branch: main
-          commit_message: "changelog update"
-          file_pattern: "CHANGELOG.md"
+    tags:
+      - 'v*'
+  release:
+    types: [published]
 
+jobs:
   cargo-publish:
     name: Cargo publish
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tembo-telemetry"
-version = "0.2.0"
+version = "0.3.0"
 description = "Logging and Telemetry exporters for Tembo.io applications"
 homepage = "https://github.com/tembo-io/tembo-telemetry"
 repository = "https://github.com/tembo-io/tembo-telemetry"
@@ -12,23 +12,25 @@ categories = [
 keywords = ["opentelemetry", "tracing"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-actix-web = "4.3"
+actix-web = "4.4"
 async-trait = "0.1"
 tracing = "0.1"
-opentelemetry = { version = "0.19", features = ["rt-tokio-current-thread", "metrics"] }
-opentelemetry-otlp = { version = "0.12", features = ["tonic", "trace", "metrics", "tls", "tls-roots"] }
+opentelemetry = { version = "0.21", default-features = false, features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.14", features = ["tonic", "trace", "tls", "tls-roots"] }
+opentelemetry_sdk = { version = "0.21", features = ["metrics", "rt-tokio-current-thread"] }
 tracing-bunyan-formatter = "0.3"
+tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "fmt"] }
-tonic = { version = "0.8", features = ["tls"]}
-tracing-opentelemetry = { version = "0.19" }
-tracing-actix-web = { version="0.7", features = ["opentelemetry_0_19"] }
+# tonic = { version = "0.9", features = ["tls"]}
+tracing-opentelemetry = { version = "0.22" }
+tracing-actix-web = { version="0.7", features = ["opentelemetry_0_21"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,11 @@ use actix_web::{
     Error,
 };
 use async_trait::async_trait;
-use opentelemetry::{
-    global, runtime::TokioCurrentThread, sdk::propagation::TraceContextPropagator, sdk::trace,
-    sdk::Resource, trace::TraceId, KeyValue,
-};
+use opentelemetry::{global, trace::TraceId, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    propagation::TraceContextPropagator, runtime::TokioCurrentThread, trace, Resource,
+};
 use tracing::Span;
 use tracing_actix_web::{DefaultRootSpanBuilder, RootSpanBuilder, TracingLogger};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
@@ -140,6 +140,11 @@ impl TelemetryInit for TelemetryConfig {
             let name: Cow<'static, str> = tracer_id.to_string().into();
             global::tracer(name);
         }
+
+        // Setup bridge between tracing crate and the log crate.  If someone
+        // uses this crate, then if they use the log crate, they will get
+        // the logs printed into the tracing session.
+        tracing_log::LogTracer::init()?;
         Ok(())
     }
 }


### PR DESCRIPTION
- Updated dependencies on the otel crates
- Added support for non-structured logging with `tracing-log`.  This allows for output from the `log` crate into a `tracing` log session.
- Bump MSRV to 1.65
- Fixed issue with CI running cargo publish