### PR TITLE
remove bunyan-formatter and just use json formatting from subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tembo-telemetry"
-version = "0.3.0"
+version = "0.3.1"
 description = "Logging and Telemetry exporters for Tembo.io applications"
 homepage = "https://github.com/tembo-io/tembo-telemetry"
 repository = "https://github.com/tembo-io/tembo-telemetry"
@@ -25,10 +25,8 @@ tracing = "0.1"
 opentelemetry = { version = "0.21", default-features = false, features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.14", features = ["tonic", "trace", "tls", "tls-roots"] }
 opentelemetry_sdk = { version = "0.21", features = ["metrics", "rt-tokio-current-thread"] }
-tracing-bunyan-formatter = "0.3"
 tracing-log = "0.2"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "fmt"] }
-# tonic = { version = "0.9", features = ["tls"]}
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "fmt", "json"] }
 tracing-opentelemetry = { version = "0.22" }
 tracing-actix-web = { version="0.7", features = ["opentelemetry_0_21"] }
 


### PR DESCRIPTION
This is to help reduce the amount of logs exported from application using this crate when distributed tracing is enabled.

before: This exposes all spans in log format
```
{"v":0,"name":"cp-webserver","msg":"[HTTP REQUEST - START]","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.616792622Z","target":"tembo_telemetry","line":187,"file":"/home/nhudson/code/tembo/tembo-telemetry/src/lib.rs"}
{"v":0,"name":"cp-webserver","msg":"[GET_ALL - START]","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.707171562Z","target":"cp_webserver::routes::instance","line":46,"file":"cp-webserver/src/routes/instance.rs"}
{"v":0,"name":"cp-webserver","msg":"[AUTH_REQUEST - START]","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.707219141Z","target":"cp_webserver::auth","line":69,"file":"cp-webserver/src/auth.rs"}
{"v":0,"name":"cp-webserver","msg":"[AUTH_REQUEST - END]","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.707337635Z","target":"cp_webserver::auth","line":69,"file":"cp-webserver/src/auth.rs"}
{"v":0,"name":"cp-webserver","msg":"[CHECK_INPUT - START]","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.707374319Z","target":"cp_webserver::db","line":31,"file":"cp-webserver/src/db.rs"}
{"v":0,"name":"cp-webserver","msg":"[CHECK_INPUT - END]","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.707391411Z","target":"cp_webserver::db","line":31,"file":"cp-webserver/src/db.rs"}
{"v":0,"name":"cp-webserver","msg":"[GET_ALL - END]","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.710214753Z","target":"cp_webserver::routes::instance","line":46,"file":"cp-webserver/src/routes/instance.rs"}
{"v":0,"name":"cp-webserver","msg":"127.0.0.1 \"GET /api/v1/orgs/org_2WjOcQXiQohBqOfwY9AL76SvYoV/instances HTTP/1.1\" 200 2 \"-\" \"curl/8.5.0\" 0.093368","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.71041165Z","target":"log","line":null,"file":null,"log.file":"/home/nhudson/.cargo/registry/src/index.crates.io-6f17d22bba15001f/actix-web-4.4.0/src/middleware/logger.rs","log.line":420,"log.target":"actix_web::middleware::logger","log.module_path":"actix_web::middleware::logger"}
{"v":0,"name":"cp-webserver","msg":"[HTTP REQUEST - END]","level":30,"hostname":"bluebeetle","pid":638924,"time":"2024-01-05T22:21:36.710443718Z","target":"tembo_telemetry","line":187,"file":"/home/nhudson/code/tembo/tembo-telemetry/src/lib.rs"}
```

after:
```
{"timestamp":"2024-01-05T23:04:03.430461Z","level":"INFO","fields":{"message":"127.0.0.1 \"GET /api/v1/orgs/org_2WjOcQXiQohBqOfwY9AL76SvYoV/instances HTTP/1.1\" 200 2 \"-\" \"curl/8.5.0\" 0.104515","log.target":"actix_web::middleware::logger","log.module_path":"actix_web::middleware::logger","log.file":"/home/nhudson/.cargo/registry/src/index.crates.io-6f17d22bba15001f/actix-web-4.4.0/src/middleware/logger.rs","log.line":420},"target":"actix_web::middleware::logger"}
```